### PR TITLE
feat: serialized field naming rule added to dotSetting file

### DIFF
--- a/Meta/Resharper/StansAssets.Global.DotSettings
+++ b/Meta/Resharper/StansAssets.Global.DotSettings
@@ -6,6 +6,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IMGUI/@EntryIndexedValue">IMGUI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IOS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="ISN_" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="ISN_PH" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="ISN_AV" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="SA_FB" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="UM_" Suffix="" Style="AaBb" /&gt;&lt;ExtraRule Prefix="AN_" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=5f0fdb63_002Dc892_002D4d2c_002D9324_002D15c80b22a7ef/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Instance" AccessRightKinds="Any" Description="Unity serialized field"&gt;&lt;ElementKinds&gt;&lt;Kind Name="UNITY_SERIALISED_FIELD" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix=" m_" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	
 
 	<!-- Non-public instance fields -->


### PR DESCRIPTION
## Purpose of this PR
Unity Serialized Field naming rule added to _.dotSetting_ file

## Testing status
* No tests have been added

## Comments to reviewers
Basically, we are going to have the following naming convention for Unity Serialized Fields.
![image](https://user-images.githubusercontent.com/1619978/236137205-f73f6a31-b778-44c2-b89d-f3a78d05fd04.png)
